### PR TITLE
move to a better reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "precommit": "npm run docs && git add documentation && npm run create-index && git add module/index.js",
     "prepush": "npm test",
     "develop": "nodangel --watch module --watch tests --exec 'npm --silent test'",
-    "istanbul": "istanbul cover ./node_modules/mocha/bin/_mocha  -- -R nyan --report lcov --compilers js:babel/register --ui qunit ./tests",
+    "istanbul": "istanbul cover ./node_modules/mocha/bin/_mocha  -- --report lcov --compilers js:babel/register --ui qunit ./tests",
     "docs": "babel-node ./utils/createDocs.js; npm run toc;",
     "toc": "doctoc ./documentation/README.md",
     "mocha": "mocha --compilers js:babel/register --ui qunit ./tests",


### PR DESCRIPTION
lets move to the default reporter of mocha.
`nyan` is funny but actually not really useful and it is a mess on travis

![screen shot 2015-05-21 at 22 12 00](https://cloud.githubusercontent.com/assets/1217681/7757970/89b1870a-0006-11e5-93cd-804d4f372448.png)


Default reporter:
```js
...
  ✓ #or
  ✓ #pick
  ✓ #pipe
  ✓ #plus
  ✓ #property
  ✓ #reduce
  ✓ #reduceFrom
  ✓ #reduceFromRight
  ✓ #reduceRight
  ✓ #replace
  ✓ #shallowClone
  ✓ #shave
  ✓ #some
  ✓ #split
  ✓ #tail
  ✓ #take
  ✓ #takeUntil
  ✓ #takeWhile
  ✓ #times
  ✓ #uncurry
  ✓ #uncurry3
  ✓ #xor

  74 passing (82ms)
```