### PR TITLE
Drop

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -17,6 +17,7 @@
 - [curry](#curry)
 - [curryRight](#curryright)
 - [dec](#dec)
+- [drop](#drop)
 - [equal](#equal)
 - [every](#every)
 - [explode](#explode)
@@ -328,6 +329,26 @@ dec(1); // => 0
 	<a href="../tests/dec.js">Spec</a>
 	•
 	<a href="../module/dec.js">Source</a>: <code> (val) =&gt; val - 1;</code>
+</sup></div>
+
+
+### drop
+
+Creates a copy of the `object` without the given `props`.
+
+```js
+const drop = require('1-liners/drop');
+
+const object = {foo: 1, bar: 2, baz: 3};
+
+drop(['foo', 'baz'], object);  // => {bar: 2}
+object;                        // => {foo: 1, bar: 2, baz: 3}
+```
+
+<div align="right"><sup>
+	<a href="../tests/drop.js">Spec</a>
+	•
+	<a href="../module/drop.js">Source</a>: <code> (props, object) =&gt; Object.keys(object).reduce((result, key) =&gt; Object.assign(result, props.includes(key) ? null : {[key]: object[key]}), {});</code>
 </sup></div>
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -348,7 +348,7 @@ object;                        // => {foo: 1, bar: 2, baz: 3}
 <div align="right"><sup>
 	<a href="../tests/drop.js">Spec</a>
 	•
-	<a href="../module/drop.js">Source</a>: <code> (props, object) =&gt; Object.keys(object).reduce((result, key) =&gt; Object.assign(result, props.includes(key) ? null : {[key]: object[key]}), {});</code>
+	<a href="../module/drop.js">Source</a>: <code> (props, object) =&gt; Object.keys(object).reduce((res, k) =&gt; Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});</code>
 </sup></div>
 
 

--- a/module/drop.js
+++ b/module/drop.js
@@ -15,4 +15,4 @@
  * 	object;                        // => {foo: 1, bar: 2, baz: 3}
  *
  */
-export default (props, object) => Object.keys(object).reduce((result, key) => Object.assign(result, props.includes(key) ? null : {[key]: object[key]}), {});
+export default (props, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});

--- a/module/drop.js
+++ b/module/drop.js
@@ -1,0 +1,18 @@
+/**
+ * @module 1-liners/drop
+ *
+ * @description
+ *
+ * Creates a copy of the `object` without the given `props`.
+ *
+ * @example
+ *
+ * 	const drop = require('1-liners/drop');
+ *
+ * 	const object = {foo: 1, bar: 2, baz: 3};
+ *
+ * 	drop(['foo', 'baz'], object);  // => {bar: 2}
+ * 	object;                        // => {foo: 1, bar: 2, baz: 3}
+ *
+ */
+export default (props, object) => Object.keys(object).reduce((result, key) => Object.assign(result, props.includes(key) ? null : {[key]: object[key]}), {});

--- a/module/index.js
+++ b/module/index.js
@@ -10,6 +10,7 @@ import converge from './converge';
 import curry from './curry';
 import curryRight from './curryRight';
 import dec from './dec';
+import drop from './drop';
 import equal from './equal';
 import every from './every';
 import explode from './explode';
@@ -90,6 +91,7 @@ export {
   curry,
   curryRight,
   dec,
+  drop,
   equal,
   every,
   explode,

--- a/tests/drop.js
+++ b/tests/drop.js
@@ -1,0 +1,23 @@
+import { deepEqual } from 'assert';
+import drop from '../drop';
+
+test('#drop', () => {
+	const object = {foo: 1, bar: 2, baz: 3};
+
+	deepEqual(
+		drop(['foo', 'baz'], object),
+		{bar: 2}
+	);
+	deepEqual(
+		drop([], object),
+		object
+	);
+	deepEqual(
+		drop(['oof'], object),
+		object
+	);
+	deepEqual(
+		object,
+		{foo: 1, bar: 2, baz: 3}
+	);
+});


### PR DESCRIPTION
### drop

Creates a copy of the `object` without the given `props`.

```js
const drop = require('1-liners/drop');

const object = {foo: 1, bar: 2, baz: 3};

drop(['foo', 'baz'], object);  // => {bar: 2}
object;                        // => {foo: 1, bar: 2, baz: 3}
```

<div align="right"><sup>
	<a href="../tests/drop.js">Spec</a>
	•
	<a href="../module/drop.js">Source</a>: <code> (props, object) =&gt; Object.keys(object).reduce((result, key) =&gt; Object.assign(result, props.includes(key) ? null : {[key]: object[key]}), {});</code>
</sup></div>

