### PR TITLE
Is plain object

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -38,6 +38,7 @@
 - [isNull](#isnull)
 - [isNumber](#isnumber)
 - [isObject](#isobject)
+- [isPlainObject](#isplainobject)
 - [isString](#isstring)
 - [isTrue](#istrue)
 - [isTruthy](#istruthy)
@@ -753,6 +754,30 @@ isObject('anything else');  // => false
 	<a href="../tests/isObject.js">Spec</a>
 	•
 	<a href="../module/isObject.js">Source</a>: <code> (value) =&gt; (value !== null &amp;&amp; typeof value === 'object');</code>
+</sup></div>
+
+
+### isPlainObject
+
+Checks if an object inherits directly from `null` or `Object.prototype` – like an object literal (`{...}`) does.
+
+Heads up! This function is [not supported on IE 10 and below](https://babeljs.io/docs/usage/caveats/).
+
+```js
+var isPlainObject = require('1-liners/isPlainObject');
+
+isPlainObject({});                   // => true
+isPlainObject(Object.create(null));  // => true
+
+isPlainObject(null);                 // => false
+isPlainObject([]);                   // => false
+isPlainObject(/anything else/);      // => false
+```
+
+<div align="right"><sup>
+	<a href="../tests/isPlainObject.js">Spec</a>
+	•
+	<a href="../module/isPlainObject.js">Source</a>: <code> (value) =&gt; (value &amp;&amp; typeof value === 'object' &amp;&amp; (value.__proto__ == null || value.__proto__ === Object.prototype));</code>
 </sup></div>
 
 

--- a/module/index.js
+++ b/module/index.js
@@ -31,6 +31,7 @@ import isFunction from './isFunction';
 import isNull from './isNull';
 import isNumber from './isNumber';
 import isObject from './isObject';
+import isPlainObject from './isPlainObject';
 import isString from './isString';
 import isTrue from './isTrue';
 import isTruthy from './isTruthy';
@@ -111,6 +112,7 @@ export {
   isNull,
   isNumber,
   isObject,
+  isPlainObject,
   isString,
   isTrue,
   isTruthy,

--- a/module/isPlainObject.js
+++ b/module/isPlainObject.js
@@ -1,0 +1,22 @@
+/**
+ * @module 1-liners/isPlainObject
+ *
+ * @description
+ *
+ * Checks if an object inherits directly from `null` or `Object.prototype` – like an object literal (`{...}`) does.
+ *
+ * Heads up! This function is [not supported on IE 10 and below](https://babeljs.io/docs/usage/caveats/).
+ *
+ * @example
+ *
+ * 	var isPlainObject = require('1-liners/isPlainObject');
+ *
+ * 	isPlainObject({});                   // => true
+ * 	isPlainObject(Object.create(null));  // => true
+ *
+ * 	isPlainObject(null);                 // => false
+ * 	isPlainObject([]);                   // => false
+ * 	isPlainObject(/anything else/);      // => false
+ *
+ */
+export default (value) => (value && typeof value === 'object' && (value.__proto__ == null || value.__proto__ === Object.prototype));

--- a/tests/isObject.js
+++ b/tests/isObject.js
@@ -5,6 +5,7 @@ test('#isObject', () => {
 	ok(isObject({}));
 	ok(isObject([]));
 	ok(isObject(/anything else/));
+	ok(isObject(Object.create(null)));
 
 	ok(!isObject(undefined));
 	ok(!isObject(null));

--- a/tests/isPlainObject.js
+++ b/tests/isPlainObject.js
@@ -1,0 +1,23 @@
+import {ok} from 'assert';
+import isPlainObject from '../isPlainObject';
+
+test('#isPlainObject', () => {
+	ok(isPlainObject({}));
+	ok(isPlainObject(Object.create(null)));
+
+	ok(!isPlainObject(undefined));
+	ok(!isPlainObject(null));
+	ok(!isPlainObject(false));
+	ok(!isPlainObject(true));
+	ok(!isPlainObject(''));
+	ok(!isPlainObject('1'));
+	ok(!isPlainObject(0));
+	ok(!isPlainObject(1));
+	ok(!isPlainObject(NaN));
+	ok(!isPlainObject(Infinity));
+	ok(!isPlainObject('non-empty string'));
+	ok(!isPlainObject([]));
+	ok(!isPlainObject(() => {}));
+	ok(!isPlainObject(function named() {}));
+	ok(!isPlainObject(/anything else/));
+});


### PR DESCRIPTION
### isPlainObject

Checks if an object inherits directly from `null` or `Object.prototype` – like an object literal (`{...}`) does.

Heads up! This function is [not supported on IE 10 and below](https://babeljs.io/docs/usage/caveats/).

```js
var isPlainObject = require('1-liners/isPlainObject');

isPlainObject({});                   // => true
isPlainObject(Object.create(null));  // => true

isPlainObject(null);                 // => false
isPlainObject([]);                   // => false
isPlainObject(/anything else/);      // => false
```

<div align="right"><sup>
	<a href="../tests/isPlainObject.js">Spec</a>
	•
	<a href="../module/isPlainObject.js">Source</a>: <code> (value) =&gt; (value &amp;&amp; typeof value === 'object' &amp;&amp; (value.__proto__ == null || value.__proto__ === Object.prototype));</code>
</sup></div>

