### PR TITLE
Add `extend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **Functional tools that couldn’t be simpler.**
 
-We’re proud to present *1-liners* – a stupid-simple functional utility belt. 82 one-liner functions, hand-crafted with love and attention.
+We’re proud to present *1-liners* – a stupid-simple functional utility belt. 83 one-liner functions, hand-crafted with love and attention.
 
 You get a product of top-quality functional programming craftmanship. Each function follows the *KISS* principle, which we’ve broken down into ten concrete rules:
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -419,7 +419,7 @@ const extend = require('1-liners/extend');
 
 const object = {id: 1};
 
-extend({ name: 'stoeffel' } object);  // => { id: 1, name: 'stoeffel' }
+extend({ name: 'stoeffel' }, object);  // => { id: 1, name: 'stoeffel' }
 ```
 
 <div align="right"><sup>

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -21,6 +21,7 @@
 - [equal](#equal)
 - [every](#every)
 - [explode](#explode)
+- [extend](#extend)
 - [filter](#filter)
 - [flip](#flip)
 - [forEach](#foreach)
@@ -406,6 +407,25 @@ explode(sum)(1, 2, 3, 4);  // => 10
 	<a href="../tests/explode.js">Spec</a>
 	•
 	<a href="../module/explode.js">Source</a>: <code> (func) =&gt; (...args) =&gt; func(args);</code>
+</sup></div>
+
+
+### extend
+
+Returns a copy of `object`, extended by `extension`.
+
+```js
+const extend = require('1-liners/extend');
+
+const object = {id: 1};
+
+extend({ name: 'stoeffel' } object);  // => { id: 1, name: 'stoeffel' }
+```
+
+<div align="right"><sup>
+	<a href="../tests/extend.js">Spec</a>
+	•
+	<a href="../module/extend.js">Source</a>: <code> (extension, object) =&gt; Object.assign({}, object, extension);</code>
 </sup></div>
 
 

--- a/module/extend.js
+++ b/module/extend.js
@@ -1,0 +1,17 @@
+/**
+ * @module 1-liners/extend
+ *
+ * @description
+ *
+ * Returns a copy of `object`, extended by `extension`.
+ *
+ * @example
+ *
+ * 	const extend = require('1-liners/extend');
+ *
+ * 	const object = {id: 1};
+ *
+ * 	extend({ name: 'stoeffel' } object);  // => { id: 1, name: 'stoeffel' }
+ *
+ */
+export default (extension, object) => Object.assign({}, object, extension);

--- a/module/extend.js
+++ b/module/extend.js
@@ -11,7 +11,7 @@
  *
  * 	const object = {id: 1};
  *
- * 	extend({ name: 'stoeffel' } object);  // => { id: 1, name: 'stoeffel' }
+ * 	extend({ name: 'stoeffel' }, object);  // => { id: 1, name: 'stoeffel' }
  *
  */
 export default (extension, object) => Object.assign({}, object, extension);

--- a/module/index.js
+++ b/module/index.js
@@ -14,6 +14,7 @@ import drop from './drop';
 import equal from './equal';
 import every from './every';
 import explode from './explode';
+import extend from './extend';
 import filter from './filter';
 import flip from './flip';
 import forEach from './forEach';
@@ -97,6 +98,7 @@ export {
   equal,
   every,
   explode,
+  extend,
   filter,
   flip,
   forEach,

--- a/tests/extend.js
+++ b/tests/extend.js
@@ -1,0 +1,9 @@
+import { deepEqual, notDeepEqual } from 'assert';
+import extend from '../extend';
+
+test('#extend', () => {
+	const object = {id: 1};
+
+	deepEqual(extend({name: 'stoeffel'}, object), { id: 1, name: 'stoeffel' });
+	notDeepEqual(extend({name: 'stoeffel'}, object), object);
+});


### PR DESCRIPTION
### extend

Returns a copy of `object`, extended by `extension`.

```js
const extend = require('1-liners/extend');

const object = {id: 1};

extend({ name: 'stoeffel' } object);  // => { id: 1, name: 'stoeffel' }
```

<div align="right"><sup>
	<a href="../tests/extend.js">Spec</a>
	•
	<a href="../module/extend.js">Source</a>: <code> (extension, object) =&gt; Object.assign({}, object, extension);</code>
</sup></div>
