### PR TITLE
adds object-assign plugin so we don't need a global ponyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["object-assign"]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "optional": ["runtime"],
-	"auxiliaryComment": "istanbul ignore next"
+  "plugins": ["object-assign"],
+	"auxiliaryCommentBefore": "istanbul ignore next"
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["object-assign"],
+  "optional": ["runtime"],
 	"auxiliaryComment": "istanbul ignore next"
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["object-assign"]
+  "plugins": ["object-assign"],
+	"auxiliaryComment": "istanbul ignore next"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "babel": "^5.5.4",
+    "babel": "^5.5.6",
+    "babel-core": "^5.5.6",
+    "babel-plugin-object-assign": "^1.1.0",
     "coveralls": "^2.11.2",
     "doctoc": "^0.13.0",
     "dox": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,11 @@
     "oneliners",
     "shorthands"
   ],
-  "dependencies": {
-    "babel-runtime": "^5.5.6"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "babel": "^5.5.6",
+    "babel": "^5.6.3",
     "babel-core": "^5.5.6",
+    "babel-plugin-object-assign": "stoeffel/babel-plugin-object-assign#252225c",
     "coveralls": "^2.11.2",
     "doctoc": "^0.13.0",
     "dox": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "oneliners",
     "shorthands"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "babel-runtime": "^5.5.6"
+  },
   "devDependencies": {
     "babel": "^5.5.6",
     "babel-core": "^5.5.6",
-    "babel-plugin-object-assign": "^1.1.0",
     "coveralls": "^2.11.2",
     "doctoc": "^0.13.0",
     "dox": "^0.8.0",


### PR DESCRIPTION
resolves https://github.com/studio-b12/tiny-error/commit/f900f3daea78d847c6a4e1f9372b3c9b2de31e18

:warning: not ready to merge. it messes up our codecoverage. 
Does anyone know how we can exlude this?
![screen shot 2015-06-09 at 17 04 03](https://cloud.githubusercontent.com/assets/1217681/8061128/9915be24-0ec9-11e5-8549-d2adcce24ba1.png)
