### PR TITLE
add babel-plugin-array-includes to convert includes to indexOf >= 0

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -380,7 +380,7 @@ object;                        // => {foo: 1, bar: 2, baz: 3}
 <div align="right"><sup>
 	<a href="../tests/drop.js">Spec</a>
 	•
-	<a href="../module/drop.js">Source</a>: <code> (props, object) =&gt; Object.keys(object).reduce((res, k) =&gt; Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});</code>
+	<a href="../module/drop.js">Source</a>: <code> (props:Array, object) =&gt; Object.keys(object).reduce((res, k) =&gt; Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});</code>
 </sup></div>
 
 

--- a/module/drop.js
+++ b/module/drop.js
@@ -15,4 +15,4 @@
  * 	object;                        // => {foo: 1, bar: 2, baz: 3}
  *
  */
-export default (props, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});
+export default (props:Array, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "updateCount": "babel-node ./utils/updateFuncCount.js;",
     "toc": "doctoc ./documentation/README.md",
     "mocha": "mocha --compilers js:babel/register --ui qunit ./tests",
-    "compile": "cd ./module; babel --loose=all --plugins object-assign --auxiliary-comment-before 'istanbul ignore next' ./*.js --out-dir ../",
+    "compile": "cd ./module; babel --loose=all --plugins object-assign,array-includes --auxiliary-comment-before 'istanbul ignore next' ./*.js --out-dir ../",
     "clean": "rm -f *.js",
     "coverage": "npm run compile; npm run istanbul; npm run clean",
     "coveralls": "npm run compile && npm run istanbul  && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && npm run clean",
@@ -42,6 +42,7 @@
   "devDependencies": {
     "babel": "^5.6.3",
     "babel-core": "^5.5.6",
+    "babel-plugin-array-includes": "^1.1.0",
     "babel-plugin-object-assign": "^1.2.0",
     "coveralls": "^2.11.2",
     "doctoc": "^0.14.1",


### PR DESCRIPTION
@tomekwi how do you like this?


i.e. `drop`
```js
exports["default"] = function (props, object) {
  return Object.keys(object).reduce(function (res, k) {
    // istanbul ignore next

    var _ref;

    return _extends(res, props.indexOf(k) >= 0 ? null : (_ref = {}, _ref[k] = object[k], _ref));
  }, {});
};

// instead of
exports["default"] = function (props, object) {
  return Object.keys(object).reduce(function (res, k) {
    // istanbul ignore next

    var _ref;

    return _extends(res, props.includes(k)? null : (_ref = {}, _ref[k] = object[k], _ref));
  }, {});
};

```