### PR TITLE
rename drop to omit and add list/array drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 **Functional tools that couldn’t be simpler.**
 
-We’re proud to present *1-liners* – a dead simple functional utility belt. **[103 one-liner functions][docs]** (and counting). Each hand-crafted with love and attention.
+We’re proud to present *1-liners* – a dead simple functional utility belt. **[104 one-liner functions][docs]** (and counting). Each hand-crafted with love and attention.
 
 [docs]:  ./documentation
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1535,7 +1535,6 @@ const omit = require('1-liners/omit');
 const object = {foo: 1, bar: 2, baz: 3};
 
 omit(['foo', 'baz'], object);  // => {bar: 2}
-object;                        // => {foo: 1, bar: 2, baz: 3}
 ```
 
 <div align="right"><sup>

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -77,6 +77,7 @@
 - [nor](#nor)
 - [not](#not)
 - [nth](#nth)
+- [omit](#omit)
 - [or](#or)
 - [pick](#pick)
 - [pipe](#pipe)
@@ -428,21 +429,22 @@ dec(1); // => 0
 
 ### drop
 
-Creates a copy of the `object` without the given `props`.
+Returns the suffix of `array` after dropping the first `n` elements
 
 ```js
 const drop = require('1-liners/drop');
 
-const object = {foo: 1, bar: 2, baz: 3};
+const array = [1, 2, 3, 4, 5];
+ const string = 'Hello World';
 
-drop(['foo', 'baz'], object);  // => {bar: 2}
-object;                        // => {foo: 1, bar: 2, baz: 3}
+drop(2, array);  // => [3, 4, 5]
+drop(6, string); // => 'World'
 ```
 
 <div align="right"><sup>
 	<a href="../tests/drop.js">Spec</a>
 	•
-	<a href="../module/drop.js">Source</a>: <code> (props:Array, object) =&gt; Object.keys(object).reduce((res, k) =&gt; Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});</code>
+	<a href="../module/drop.js">Source</a>: <code> (n, array) =&gt; array.slice(Math.max(n, 0), Infinity);</code>
 </sup></div>
 
 
@@ -1520,6 +1522,26 @@ nth(1, [1, 2, 3]); // => 2
 	<a href="../tests/nth.js">Spec</a>
 	•
 	<a href="../module/nth.js">Source</a>: <code> (n, arr) =&gt; arr[n];</code>
+</sup></div>
+
+
+### omit
+
+Creates a copy of the `object` without the given `props`.
+
+```js
+const omit = require('1-liners/omit');
+
+const object = {foo: 1, bar: 2, baz: 3};
+
+omit(['foo', 'baz'], object);  // => {bar: 2}
+object;                        // => {foo: 1, bar: 2, baz: 3}
+```
+
+<div align="right"><sup>
+	<a href="../tests/omit.js">Spec</a>
+	•
+	<a href="../module/omit.js">Source</a>: <code> (props:Array, object) =&gt; Object.keys(object).reduce((res, k) =&gt; Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});</code>
 </sup></div>
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -429,7 +429,7 @@ dec(1); // => 0
 
 ### drop
 
-Returns the suffix of `array` after dropping the first `n` elements
+Returns the tail of `array` after dropping the first `n` elements
 
 ```js
 const drop = require('1-liners/drop');

--- a/module/drop.js
+++ b/module/drop.js
@@ -3,7 +3,7 @@
  *
  * @description
  *
- * Returns the suffix of `array` after dropping the first `n` elements
+ * Returns the tail of `array` after dropping the first `n` elements
  *
  * @example
  *
@@ -11,7 +11,7 @@
  *
  * 	const array = [1, 2, 3, 4, 5];
  *  const string = 'Hello World';
- * 
+ *
  * 	drop(2, array);  // => [3, 4, 5]
  * 	drop(6, string); // => 'World'
  *

--- a/module/drop.js
+++ b/module/drop.js
@@ -3,16 +3,17 @@
  *
  * @description
  *
- * Creates a copy of the `object` without the given `props`.
+ * Returns the suffix of `array` after dropping the first `n` elements
  *
  * @example
  *
  * 	const drop = require('1-liners/drop');
  *
- * 	const object = {foo: 1, bar: 2, baz: 3};
- *
- * 	drop(['foo', 'baz'], object);  // => {bar: 2}
- * 	object;                        // => {foo: 1, bar: 2, baz: 3}
+ * 	const array = [1, 2, 3, 4, 5];
+ *  const string = 'Hello World';
+ * 
+ * 	drop(2, array);  // => [3, 4, 5]
+ * 	drop(6, string); // => 'World'
  *
  */
-export default (props:Array, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});
+export default (n, array) => array.slice(Math.max(n, 0), Infinity);

--- a/module/index.js
+++ b/module/index.js
@@ -70,6 +70,7 @@ import noop from './noop';
 import nor from './nor';
 import not from './not';
 import nth from './nth';
+import omit from './omit';
 import or from './or';
 import pick from './pick';
 import pipe from './pipe';
@@ -174,6 +175,7 @@ export {
   nor,
   not,
   nth,
+  omit,
   or,
   pick,
   pipe,

--- a/module/omit.js
+++ b/module/omit.js
@@ -1,0 +1,18 @@
+/**
+ * @module 1-liners/omit
+ *
+ * @description
+ *
+ * Creates a copy of the `object` without the given `props`.
+ *
+ * @example
+ *
+ * 	const omit = require('1-liners/omit');
+ *
+ * 	const object = {foo: 1, bar: 2, baz: 3};
+ *
+ * 	omit(['foo', 'baz'], object);  // => {bar: 2}
+ * 	object;                        // => {foo: 1, bar: 2, baz: 3}
+ *
+ */
+export default (props:Array, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});

--- a/module/omit.js
+++ b/module/omit.js
@@ -12,7 +12,7 @@
  * 	const object = {foo: 1, bar: 2, baz: 3};
  *
  * 	omit(['foo', 'baz'], object);  // => {bar: 2}
- * 	object;                        // => {foo: 1, bar: 2, baz: 3}
+ *
  *
  */
 export default (props:Array, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});

--- a/tests/drop.js
+++ b/tests/drop.js
@@ -2,22 +2,10 @@ import { deepEqual } from 'assert';
 import drop from '../drop';
 
 test('#drop', () => {
-	const object = {foo: 1, bar: 2, baz: 3};
+	const array = [1, 2, 3, 4, 5];
+	const string = 'Hello World';
 
-	deepEqual(
-		drop(['foo', 'baz'], object),
-		{bar: 2}
-	);
-	deepEqual(
-		drop([], object),
-		object
-	);
-	deepEqual(
-		drop(['oof'], object),
-		object
-	);
-	deepEqual(
-		object,
-		{foo: 1, bar: 2, baz: 3}
-	);
+	deepEqual(drop(2, array), [3, 4, 5]);
+	deepEqual(drop(array.length + 1, array), []);
+    deepEqual(drop(6, string), 'World');
 });

--- a/tests/omit.js
+++ b/tests/omit.js
@@ -1,0 +1,23 @@
+import { deepEqual } from 'assert';
+import omit from '../omit';
+
+test('#omit', () => {
+	const object = {foo: 1, bar: 2, baz: 3};
+
+	deepEqual(
+		omit(['foo', 'baz'], object),
+		{bar: 2}
+	);
+	deepEqual(
+		omit([], object),
+		object
+	);
+	deepEqual(
+		omit(['oof'], object),
+		object
+	);
+	deepEqual(
+		object,
+		{foo: 1, bar: 2, baz: 3}
+	);
+});


### PR DESCRIPTION
This PR covers the proposal mentioned in https://github.com/1-liners/1-liners/issues/140

- [x] Rename current [drop](https://github.com/1-liners/1-liners/tree/master/documentation#drop) to omit for consistency with other libraries, etc
- [x] Implement a new `drop` that works on lists or arrays ie: `drop(1, [1, 2, 3]) returns [2, 3]`