### PR TITLE
refactor omit

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1616,7 +1616,7 @@ omit(['foo', 'baz'], object);  // => {bar: 2}
 <div align="right"><sup>
 	<a href="../tests/omit.js">Spec</a>
 	•
-	<a href="../module/omit.js">Source</a>: <code> (props:Array, object) =&gt; Object.keys(object).reduce((res, k) =&gt; Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});</code>
+	<a href="../module/omit.js">Source</a>: <code> (props, obj) =&gt; props.reduce((newObj, val) =&gt; (({ [val]: dropped, ...rest }) =&gt; rest)(newObj), obj);</code>
 </sup></div>
 
 

--- a/module/omit.js
+++ b/module/omit.js
@@ -15,4 +15,4 @@
  *
  *
  */
-export default (props:Array, object) => Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {});
+export default (props, obj) => props.reduce((newObj, val) => (({ [val]: dropped, ...rest }) => rest)(newObj), obj);


### PR DESCRIPTION
How do you like this @1-liners/maintainers ?

```js
Object.keys(object).reduce((res, k) => Object.assign(res, props.includes(k) ? null : {[k]: object[k]}), {}); // before
props.reduce((res, v) => (({ [v]: x, ...r }) => r)(res), obj); // after
```