### PR TITLE
Use `.reduceRight` instead of `.reverse().reduce`

### DIFF
--- a/module/pipeAll.js
+++ b/module/pipeAll.js
@@ -12,4 +12,4 @@
  * 	pipeAll([f, g, h])(1, 2) === h(g(f(1, 2)));
  * 
  */
-export default (fns) => fns.reverse().reduce( (f, g) => (...args) => f(g(...args)) );
+export default (fns) => fns.reduceRight( (f, g) => (...args) => f(g(...args)) );


### PR DESCRIPTION
 `reduceRight` [has good browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/ReduceRight#Browser_compatibility) and skips the [mutating `reverse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse)