### PR TITLE
reduce - rename reduce arg for clarity

### DIFF
--- a/module/reduce.js
+++ b/module/reduce.js
@@ -12,4 +12,4 @@
  * 	reduce(sum, [1, 2, 3]); // => 6
  * 
  */
-export default (reduce, arr) => arr.reduce(reduce);
+export default (func, arr) => arr.reduce(func);


### PR DESCRIPTION
It'd be better called `func` to separate its name from `reduce` itself