### PR TITLE
Added entries func

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 **Functional tools that couldn’t be simpler.**
 
-We’re proud to present *1-liners* – a dead simple functional utility belt. **[121 one-liner functions][docs]** (and counting). Each hand-crafted with love and attention.
+We’re proud to present *1-liners* – a dead simple functional utility belt. **[122 one-liner functions][docs]** (and counting). Each hand-crafted with love and attention.
 
 [docs]:  ./documentation
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -29,6 +29,7 @@
 - [drop](#drop)
 - [endsWith](#endswith)
 - [endsWithAt](#endswithat)
+- [entries](#entries)
 - [equal](#equal)
 - [every](#every)
 - [exec](#exec)
@@ -588,6 +589,27 @@ endsWithAt(2, 'stoeffel', 'nope');  // => false
 	<a href="../tests/endsWithAt.js">Spec</a>
 	•
 	<a href="../module/endsWithAt.js">Source</a>: <code> (position, searchString, str) =&gt; str.endsWith(searchString, position);</code>
+</sup></div>
+
+
+### entries
+
+Returns an array of a given object's own enumerable property [key, value] pairs
+Same as `Object.keys(obj).map(key => [key, obj[key]])`.
+
+```js
+const entries = require('1-liners/entries');
+
+entries({ foo: 'bar', baz: 42 }); // => [ ['foo', 'bar'], ['baz', 42] ]
+entries(['foo', 'bar', 'baz']); // => [ [0, 'foo'], [1, 'bar'], [2, 'baz'] ]
+entries({ foo: 'bar', [Symbol('baz')]: 42 }); // => [ ['foo', 'bar'] ]
+entries('foo'); // => [ ['0', 'f'], ['1', 'o'], ['2', 'o'] ]
+```
+
+<div align="right"><sup>
+	<a href="../tests/entries.js">Spec</a>
+	•
+	<a href="../module/entries.js">Source</a>: <code> (obj) =&gt; Object.keys(obj).map(key =&gt; [key, obj[key]]);</code>
 </sup></div>
 
 
@@ -1909,7 +1931,7 @@ reduce(sum, [1, 2, 3]); // => 6
 <div align="right"><sup>
 	<a href="../tests/reduce.js">Spec</a>
 	•
-	<a href="../module/reduce.js">Source</a>: <code> (reduce, arr) =&gt; arr.reduce(reduce);</code>
+	<a href="../module/reduce.js">Source</a>: <code> (func, arr) =&gt; arr.reduce(func);</code>
 </sup></div>
 
 

--- a/module/entries.js
+++ b/module/entries.js
@@ -1,0 +1,18 @@
+/**
+ * @module 1-liners/entries
+ *
+ * @description
+ *
+ * Returns an array of a given object's own enumerable property [key, value] pairs
+ * Same as `Object.keys(obj).map(key => [key, obj[key]])`.
+ *
+ * @example
+ *
+ * 	const entries = require('1-liners/entries');
+ *
+ * 	entries({ foo: 'bar', baz: 42 }); // => [ ['foo', 'bar'], ['baz', 42] ]
+ * 	entries(['foo', 'bar', 'baz']); // => [ [0, 'foo'], [1, 'bar'], [2, 'baz'] ]
+ * 	entries({ foo: 'bar', [Symbol('baz')]: 42 }); // => [ ['foo', 'bar'] ]
+ * 	entries('foo'); // => [ ['0', 'f'], ['1', 'o'], ['2', 'o'] ]
+ */
+export default (obj) => Object.keys(obj).map(key => [key, obj[key]]);

--- a/module/index.js
+++ b/module/index.js
@@ -22,6 +22,7 @@ import dec from './dec';
 import drop from './drop';
 import endsWith from './endsWith';
 import endsWithAt from './endsWithAt';
+import entries from './entries';
 import equal from './equal';
 import every from './every';
 import exec from './exec';
@@ -144,6 +145,7 @@ export {
   drop,
   endsWith,
   endsWithAt,
+  entries,
   equal,
   every,
   exec,

--- a/tests/entries.js
+++ b/tests/entries.js
@@ -1,0 +1,10 @@
+import { deepEqual } from 'assert';
+import entries from '../entries';
+
+test('#entries', () => {
+  deepEqual(entries({ foo: 'bar', baz: 42 }), [ ['foo', 'bar'], ['baz', 42] ]);
+  deepEqual(entries(['foo', 'bar', 'baz']), [ [0, 'foo'], [1, 'bar'], [2, 'baz'] ]);
+  deepEqual(entries({ foo: 'bar', [Symbol('baz')]: 42 }), [ ['foo', 'bar'] ]);
+  deepEqual(entries('foo'), [ ['0', 'f'], ['1', 'o'], ['2', 'o'] ]);
+  deepEqual(entries(Object.create({}, { getFoo: function() { return this.foo; } })), []);
+});


### PR DESCRIPTION
`entries()` ([msdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)) returns an array whose elements are arrays corresponding to the enumerable property `[key, value]` pairs found directly upon object. The ordering of the properties is the same as that given by looping over the property values of the object manually.
