### PR TITLE
fix typo in README, bump version number

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1811,9 +1811,9 @@ const partial = require('1-liners/partial');
 
 const add = (a, b, c) => a + b + c;
 
- const fivePlus = (add, 2, 3);
+const fivePlus = partial(add, 2, 3);
 
- fivePlus(4) === 9
+fivePlus(4) // => 9
 ```
 
 <div align="right"><sup>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1-liners",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Useful oneliners and shorthand functions",
   "license": "MIT",
   "repository": "1-liners/1-liners",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1-liners",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Useful oneliners and shorthand functions",
   "license": "MIT",
   "repository": "1-liners/1-liners",


### PR DESCRIPTION
Hello,

First of all, thank you for this project, I just discovered it yesterday and it's really cool :)

I'm a junior developper so pardon me if I'm not doing things properly.

So...I fixed a simple typo in the README file, and the reason I bumped the version number is to be able to get a copy that is up-to-date with the latests updates committed to the repo when downloading from npm.

Currently you get a version that matches with the commit a79ddf0, which dates back to last year.

Cheers


