### PR TITLE
Improve unfold

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2525,16 +2525,12 @@ unfold(fn, 10); // => [10,11,12,13,14,15,16,17,18,19]
 // range in terms of unfold
 const range = (from, to) => unfold((seed) => seed < to ? [seed, seed + 1] : false, from);
 range(1, 10); // => [1,2,3,4,5,6,7,8,9]
-
-// unnest in terms of unfold
-const unnest = xs => unfold((seed) => seed < xs.length ? [xs[seed], seed + 1] : false , 0);
-unnest([[1, 2], [3, 4], [5, 6]]); // => [1,2,3,4,5,6]
 ```
 
 <div align="right"><sup>
 	<a href="../tests/unfold.js">Spec</a>
 	•
-	<a href="../module/unfold.js">Source</a>: <code> function unfold (fn, seed, acc = [], next = fn(seed)) { return next ? unfold(fn, next[1], acc.concat.apply(acc, [next[0]])) : acc }</code>
+	<a href="../module/unfold.js">Source</a>: <code> function unfold (fn, seed, acc = [], next = fn(seed)) { return next ? unfold(fn, next[1], [...acc, next[0]]) : acc }</code>
 </sup></div>
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2534,7 +2534,7 @@ unnest([[1, 2], [3, 4], [5, 6]]); // => [1,2,3,4,5,6]
 <div align="right"><sup>
 	<a href="../tests/unfold.js">Spec</a>
 	•
-	<a href="../module/unfold.js">Source</a>: <code> function unfold (fn, seed, acc = []) { return fn(seed) ? unfold(fn, fn(seed)[1], acc.concat.apply(acc, [fn(seed)[0]])) : acc }</code>
+	<a href="../module/unfold.js">Source</a>: <code> function unfold (fn, seed, acc = [], next = fn(seed)) { return next ? unfold(fn, next[1], acc.concat.apply(acc, [next[0]])) : acc }</code>
 </sup></div>
 
 

--- a/module/unfold.js
+++ b/module/unfold.js
@@ -15,10 +15,5 @@
  * // range in terms of unfold
  * const range = (from, to) => unfold((seed) => seed < to ? [seed, seed + 1] : false, from);
  * range(1, 10); // => [1,2,3,4,5,6,7,8,9]
- *
- * // unnest in terms of unfold
- * const unnest = xs => unfold((seed) => seed < xs.length ? [xs[seed], seed + 1] : false , 0);
- * unnest([[1, 2], [3, 4], [5, 6]]); // => [1,2,3,4,5,6]
- *
  */
-export default function unfold (fn, seed, acc = [], next = fn(seed)) { return next ? unfold(fn, next[1], acc.concat.apply(acc, [next[0]])) : acc }
+export default function unfold (fn, seed, acc = [], next = fn(seed)) { return next ? unfold(fn, next[1], [...acc, next[0]]) : acc }

--- a/module/unfold.js
+++ b/module/unfold.js
@@ -21,4 +21,4 @@
  * unnest([[1, 2], [3, 4], [5, 6]]); // => [1,2,3,4,5,6]
  *
  */
-export default function unfold (fn, seed, acc = []) { return fn(seed) ? unfold(fn, fn(seed)[1], acc.concat.apply(acc, [fn(seed)[0]])) : acc }
+export default function unfold (fn, seed, acc = [], next = fn(seed)) { return next ? unfold(fn, next[1], acc.concat.apply(acc, [next[0]])) : acc }


### PR DESCRIPTION
So I was looking at the `unfold` documentation and saw this example:

```javascript
const unnest = xs => unfold((seed) => seed < xs.length ? [xs[seed], seed + 1] : false , 0);
unnest([[1, 2], [3, 4], [5, 6]]); // => [1,2,3,4,5,6]
```

That worked because `unfold` used `acc.concat.apply(acc, [fn(seed)[0]]))` to concatenate results.

But that looks broken to me (put aside the unnecessary/costly apply) because, for example, one could not generate a list of Cartesian points (unless you wrap the result into an array) – I would expect `unfold` to behave like [Ramda's unfold](http://ramdajs.com/docs/#unfold), where the data type returned by `fn` doesn't change the behavior.

Also, under previous implementation, `fn` was called 3 times for each iteration. Since default params are evaluated lazily, we can call it in there.