### PR TITLE
Update docs

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2111,7 +2111,7 @@ from start(including) to end(excluding)
 ```js
 const range = require('1-liners/range');
 
-range(1, 5); // => [1, 2, 3, 4, 5]
+range(1, 5); // => [1, 2, 3, 4]
 ```
 
 <div align="right"><sup>


### PR DESCRIPTION
The range function returns an array with a range of values between the minimum and maximum initial value excluding the maximum value. The documentation example still contains the maximum value. This pull request is to correct this.